### PR TITLE
fix: SmartDate handles null cases

### DIFF
--- a/examples/fields/SmartDateField.spec.ts
+++ b/examples/fields/SmartDateField.spec.ts
@@ -1,19 +1,76 @@
 import * as _ from 'lodash'
 import { SmartDateField, ChronoDateCast } from './SmartDateField'
 import { FlatfileRecord } from '@flatfile/hooks'
-import { Workbook, Sheet, TextField } from '@flatfile/configure'
-import { SheetTester, matchSingleMessage } from '../../src/utils/testing/SheetTester'
+import { Workbook, Sheet, TextField, NumberField } from '@flatfile/configure'
+import {
+  SheetTester,
+  matchSingleMessage,
+} from '../../src/utils/testing/SheetTester'
 
 const CompSets = [
-  { expResult: 'error___', before: '18/02/2009', /*--*/ after: '02/17/2009', bF: '2009-02-18', aF: '2009-02-17' },
-  { expResult: "No Error", before: "02/17/2009", /*--*/ after: "2009/02/19", bF: '2009-02-17', aF: '2009-02-19' },
-  { expResult: "No Error", before: "2009/02/19", /*--*/ after: "February 20, 2009", bF: '2009-02-19', aF: '2009-02-20' },
-  { expResult: "error___", before: "2/21/2009", /*--*/ after: "February 20, 2009", bF: '2009-02-21', aF: '2009-02-20' },
-  { expResult: "error___", before: "22/2/2009", /*---*/ after: "2009/02/19", bF: '2009-02-22', aF: '2009-02-19' },
-  { expResult: "No Error", before: "2/21/2009", /*---*/ after: "2009/2/23", bF: '2009-02-21', aF: '2009-02-23' },
-  { expResult: "No Error", before: "February 20, 2009", after: " 2/24/2009", bF: '2009-02-20', aF: '2009-02-24' },
-  { expResult: "No Error", before: "February 20, 2009", after: "25Feb2009", bF: '2009-02-20', aF: '2009-02-25' },
-  { expResult: "No Error", before: " 2/8/2009", /*---*/ after: " 8/2/2009", bF: '2009-02-08', aF: '2009-08-02' },
+  {
+    expResult: 'error___',
+    before: '18/02/2009',
+    /*--*/ after: '02/17/2009',
+    bF: '2009-02-18',
+    aF: '2009-02-17',
+  },
+  {
+    expResult: 'No Error',
+    before: '02/17/2009',
+    /*--*/ after: '2009/02/19',
+    bF: '2009-02-17',
+    aF: '2009-02-19',
+  },
+  {
+    expResult: 'No Error',
+    before: '2009/02/19',
+    /*--*/ after: 'February 20, 2009',
+    bF: '2009-02-19',
+    aF: '2009-02-20',
+  },
+  {
+    expResult: 'error___',
+    before: '2/21/2009',
+    /*--*/ after: 'February 20, 2009',
+    bF: '2009-02-21',
+    aF: '2009-02-20',
+  },
+  {
+    expResult: 'error___',
+    before: '22/2/2009',
+    /*---*/ after: '2009/02/19',
+    bF: '2009-02-22',
+    aF: '2009-02-19',
+  },
+  {
+    expResult: 'No Error',
+    before: '2/21/2009',
+    /*---*/ after: '2009/2/23',
+    bF: '2009-02-21',
+    aF: '2009-02-23',
+  },
+  {
+    expResult: 'No Error',
+    before: 'February 20, 2009',
+    after: ' 2/24/2009',
+    bF: '2009-02-20',
+    aF: '2009-02-24',
+  },
+  {
+    expResult: 'No Error',
+    before: 'February 20, 2009',
+    after: '25Feb2009',
+    bF: '2009-02-20',
+    aF: '2009-02-25',
+  },
+  {
+    expResult: 'No Error',
+    before: ' 2/8/2009',
+    /*---*/ after: ' 8/2/2009',
+    bF: '2009-02-08',
+    aF: '2009-08-02',
+  },
 ]
 
 const DateSheet = new Sheet(
@@ -30,28 +87,49 @@ const DateSheet = new Sheet(
       //@ts-ignore
       const notBefore = before > after
       if (bothPresent && notBefore) {
-        record.addError(['before', 'after'], "field 'before' must be a date before 'after'")
+        record.addError(
+          ['before', 'after'],
+          "field 'before' must be a date before 'after'"
+        )
       }
     },
   }
 )
-const SmartDateCompBook = new Workbook({ name: 'DateBook', namespace: 'test', sheets: { DateSheet } })
+const SmartDateCompBook = new Workbook({
+  name: 'DateBook',
+  namespace: 'test',
+  sheets: { DateSheet },
+})
 
 describe('Date Comp Sheet tests demonstrating comparison of date object ->', () => {
   const testSheet = new SheetTester(SmartDateCompBook, 'DateSheet')
-  test.each(CompSets)('Verify that before is earlier than after for sample data', async (row) => {
-    const results = await testSheet.testRecord(row)
-    expect(results['before']).toBe(row['bF'])
-    expect(results['after']).toBe(row['aF'])
-    const messageRes = await testSheet.testMessage(row)
-    if (row['expResult'] === 'No Error') {
-      expect(matchSingleMessage(messageRes, 'before', "field 'before' must be a date before 'after'")).toBeFalsy()
-    } else {
-      expect(matchSingleMessage(messageRes, 'before', "field 'before' must be a date before 'after'")).toBeTruthy()
+  test.each(CompSets)(
+    'Verify that before is earlier than after for sample data',
+    async (row) => {
+      const results = await testSheet.testRecord(row)
+      expect(results['before']).toBe(row['bF'])
+      expect(results['after']).toBe(row['aF'])
+      const messageRes = await testSheet.testMessage(row)
+      if (row['expResult'] === 'No Error') {
+        expect(
+          matchSingleMessage(
+            messageRes,
+            'before',
+            "field 'before' must be a date before 'after'"
+          )
+        ).toBeFalsy()
+      } else {
+        expect(
+          matchSingleMessage(
+            messageRes,
+            'before',
+            "field 'before' must be a date before 'after'"
+          )
+        ).toBeTruthy()
+      }
     }
-  })
+  )
 })
-
 
 const CompSets2 = [
   // these rows don't work with simple built in JS Date
@@ -59,12 +137,48 @@ const CompSets2 = [
   // { expResult: "error___", before: "22/2/2009", /*---*/ after: "2009/02/19", bF: '2009-2-22', aF: '2009-2-19'},
   // { expResult: "No Error", before: " 2/8/2009", /*---*/ after: " 8/2/2009", bF: '2009-2-08', aF: '2009-8-02'},
 
-  { expResult: "No Error", before: "02/17/2009", /*--*/ after: "2009/02/19", bF: '2009-2-17', aF: '2009-2-19' },
-  { expResult: "No Error", before: "2009/02/19", /*--*/ after: "February 20, 2009", bF: '2009-2-19', aF: '2009-2-20' },
-  { expResult: "error___", before: "2/21/2009", /*--*/ after: "February 20, 2009", bF: '2009-2-21', aF: '2009-2-20' },
-  { expResult: "No Error", before: "2/21/2009", /*---*/ after: "2009/2/23", bF: '2009-2-21', aF: '2009-2-23' },
-  { expResult: "No Error", before: "February 20, 2009", after: " 2/24/2009", bF: '2009-2-20', aF: '2009-2-24' },
-  { expResult: "No Error", before: "February 20, 2009", after: "25Feb2009", bF: '2009-2-20', aF: '2009-2-25' },
+  {
+    expResult: 'No Error',
+    before: '02/17/2009',
+    /*--*/ after: '2009/02/19',
+    bF: '2009-2-17',
+    aF: '2009-2-19',
+  },
+  {
+    expResult: 'No Error',
+    before: '2009/02/19',
+    /*--*/ after: 'February 20, 2009',
+    bF: '2009-2-19',
+    aF: '2009-2-20',
+  },
+  {
+    expResult: 'error___',
+    before: '2/21/2009',
+    /*--*/ after: 'February 20, 2009',
+    bF: '2009-2-21',
+    aF: '2009-2-20',
+  },
+  {
+    expResult: 'No Error',
+    before: '2/21/2009',
+    /*---*/ after: '2009/2/23',
+    bF: '2009-2-21',
+    aF: '2009-2-23',
+  },
+  {
+    expResult: 'No Error',
+    before: 'February 20, 2009',
+    after: ' 2/24/2009',
+    bF: '2009-2-20',
+    aF: '2009-2-24',
+  },
+  {
+    expResult: 'No Error',
+    before: 'February 20, 2009',
+    after: '25Feb2009',
+    bF: '2009-2-20',
+    aF: '2009-2-25',
+  },
 ]
 
 const DumbDateSheet = new Sheet(
@@ -82,33 +196,60 @@ const DumbDateSheet = new Sheet(
         const bothPresent = before && after
         const notBefore = before > after
         if (bothPresent && notBefore) {
-          record.addError(['before', 'after'], "field 'before' must be a date before 'after'")
+          record.addError(
+            ['before', 'after'],
+            "field 'before' must be a date before 'after'"
+          )
         }
-        record.set('before', `${before.getUTCFullYear()}-${before.getUTCMonth() + 1}-${before.getUTCDate()}`)
-        record.set('after', `${after.getUTCFullYear()}-${after.getUTCMonth() + 1}-${after.getUTCDate()}`)
+        record.set(
+          'before',
+          `${before.getUTCFullYear()}-${
+            before.getUTCMonth() + 1
+          }-${before.getUTCDate()}`
+        )
+        record.set(
+          'after',
+          `${after.getUTCFullYear()}-${
+            after.getUTCMonth() + 1
+          }-${after.getUTCDate()}`
+        )
       }
     },
   }
 )
 
-const DumbDateCompBook = new Workbook({ name: 'DumbDateCompBook', namespace: 'test', sheets: { DumbDateSheet } })
+const DumbDateCompBook = new Workbook({
+  name: 'DumbDateCompBook',
+  namespace: 'test',
+  sheets: { DumbDateSheet },
+})
 
 describe('Dumb Date Comp Sheet ->', () => {
   const testSheet = new SheetTester(DumbDateCompBook, 'DumbDateSheet')
   test.each(CompSets2)('date comparison', async (row) => {
-
     const messageRes = await testSheet.testMessage(row)
     if (row['expResult'] === 'No Error') {
-      expect(matchSingleMessage(messageRes, 'before', "field 'before' must be a date before 'after'")).toBeFalsy()
+      expect(
+        matchSingleMessage(
+          messageRes,
+          'before',
+          "field 'before' must be a date before 'after'"
+        )
+      ).toBeFalsy()
     } else {
-      expect(matchSingleMessage(messageRes, 'before', "field 'before' must be a date before 'after'")).toBeTruthy()
+      expect(
+        matchSingleMessage(
+          messageRes,
+          'before',
+          "field 'before' must be a date before 'after'"
+        )
+      ).toBeTruthy()
     }
     const results = await testSheet.testRecord(row)
     expect(results['before']).toBe(row['bF'])
     expect(results['after']).toBe(row['aF'])
   })
 })
-
 
 // working dates
 /*
@@ -125,32 +266,41 @@ describe('Extra test ->', () => {
     },
     {}
   )
-  const SmartDateBook = new Workbook({ name: 'DateBook', namespace: 'test', sheets: { SmartDateSheet } })
+  const SmartDateBook = new Workbook({
+    name: 'DateBook',
+    namespace: 'test',
+    sheets: { SmartDateSheet },
+  })
 
-  const dErr = (d: string) => `Error: couldn't parse ${d} with a certain year.  Please use an unambiguous date format`
-  const dayErr = (d: string) => `Error: couldn't parse ${d} with a certain day.  Please use an unambiguous date format`
+  const dErr = (d: string) =>
+    `Error: couldn't parse ${d} with a certain year.  Please use an unambiguous date format`
+  const dayErr = (d: string) =>
+    `Error: couldn't parse ${d} with a certain day.  Please use an unambiguous date format`
   const noParse = (d: string) => `Error: '${d}' returned no parse results`
 
   const testSheet = new SheetTester(SmartDateBook, 'SmartDateSheet')
-  const failingDates = _.map([
-    ["25-Feb-19", dErr],
-    ["17/ 2/2009", dayErr], //"bD/bM/YY" #Day-Month-Year with spaces instead of leading zeros
-    ["2009/ 2/17", dErr], //"YY/bM/bD" #Year-Month-Day with spaces instead of leading zeros
-    ["20090217", noParse],  //"YYMMDD",  #Year-Month-Day with no separators
+  const failingDates = _.map(
+    [
+      ['25-Feb-19', dErr],
+      ['17/ 2/2009', dayErr], //"bD/bM/YY" #Day-Month-Year with spaces instead of leading zeros
+      ['2009/ 2/17', dErr], //"YY/bM/bD" #Year-Month-Day with spaces instead of leading zeros
+      ['20090217', noParse], //"YYMMDD",  #Year-Month-Day with no separators
 
-    ["2009, Feb 17", dErr], // "YYYYY-Mon-DD"  #Year, Month abbreviation, Day with leading zeros
-    ["2009, Feb 17", dErr], // "YYYY, Mon DD"  #Year, Month abbreviation, Day with leading zeros
+      ['2009, Feb 17', dErr], // "YYYYY-Mon-DD"  #Year, Month abbreviation, Day with leading zeros
+      ['2009, Feb 17', dErr], // "YYYY, Mon DD"  #Year, Month abbreviation, Day with leading zeros
 
-    ["02172009", noParse], // "MMDDYY"  #Month-Day-Year with no separators
-    ["17022009", noParse],  // "DDMMYY" #Day-Month-Year with no separators
-    ["2009Feb17", noParse], // "YYMonDD" #Year-Month abbreviation-Day with leading zeros
-    ["48/2009", noParse],   // "day/YY"  #Day of year (counting consecutively from January 1)-Year 
-    ["2009/48", noParse],  // "YY/day" #Year-Day of Year (counting consecutively from January 1—often called the Julian date format)
-  ], (combinedArg) => {
-    const [d, func] = combinedArg
-    //@ts-ignore
-    return [d, func(d)]
-  })
+      ['02172009', noParse], // "MMDDYY"  #Month-Day-Year with no separators
+      ['17022009', noParse], // "DDMMYY" #Day-Month-Year with no separators
+      ['2009Feb17', noParse], // "YYMonDD" #Year-Month abbreviation-Day with leading zeros
+      ['48/2009', noParse], // "day/YY"  #Day of year (counting consecutively from January 1)-Year
+      ['2009/48', noParse], // "YY/day" #Year-Day of Year (counting consecutively from January 1—often called the Julian date format)
+    ],
+    (combinedArg) => {
+      const [d, func] = combinedArg
+      //@ts-ignore
+      return [d, func(d)]
+    }
+  )
 
   test.each(failingDates)('date comparison', async (d, err) => {
     const row = { d }
@@ -158,25 +308,61 @@ describe('Extra test ->', () => {
     const results = await testSheet.testRecord(row)
     expect(messageRes[0]).toMatchObject({ message: err })
   })
-
 })
 
 describe('SmartDateField tests ->', () => {
   test('prevent egressCycle errors at instantiation time', () => {
     expect(() => {
       SmartDateField({ formatString: "yyyy-MM-dd'paddy'" })
-    })
-      .toThrow("Error: instantiating a SmartDateField with a formatString of yyyy-MM-dd'paddy', and locale of 'en'.  will result in data loss or unexpected behavior")
+    }).toThrow(
+      "Error: instantiating a SmartDateField with a formatString of yyyy-MM-dd'paddy', and locale of 'en'.  will result in data loss or unexpected behavior"
+    )
 
     expect(() => {
       SmartDateField({ locale: 'fr', formatString: "MM-dd-yy'" })
-    })
-      .toThrow("Error: instantiating a SmartDateField with a formatString of MM-dd-yy', and locale of 'fr'.  will result in data loss or unexpected behavior")
+    }).toThrow(
+      "Error: instantiating a SmartDateField with a formatString of MM-dd-yy', and locale of 'fr'.  will result in data loss or unexpected behavior"
+    )
     //we expect the following to work because that is the default for en locale
     SmartDateField({ formatString: "MM-dd-yy'" })
   })
 })
 
+const NullValuesSheet = new Sheet('NullValuesSheet', {
+  thisDate: SmartDateField({
+    formatString: 'yyyy-MM-dd',
+  }),
+})
+
+const NullValuesWorkbook = new Workbook({
+  name: 'NullValuesWorkbook',
+  namespace: 'test',
+  sheets: { NullValuesSheet },
+})
+
+describe('SmartDateField handles null values', () => {
+  const testSheet = new SheetTester(NullValuesWorkbook, 'NullValuesSheet')
+  const rows = [
+    {
+      thisDate: null,
+    },
+    {
+      thisDate: undefined,
+    },
+    {
+      thisDate: '',
+    },
+  ]
+  test.each(rows)(
+    'Verify that result is null and there are no errors',
+    async (row) => {
+      const results = await testSheet.testRecord(row)
+      const message = await testSheet.testMessage(row)
+      expect(results['thisDate']).toBe(null)
+      expect(message.length === 0)
+    }
+  )
+})
 
 describe('Cast Function tests ->', () => {
   const makeCastAssertException = (castFn: any) => {
@@ -210,7 +396,10 @@ describe('Cast Function tests ->', () => {
   })
 
   test('DateCast handles infinity as an error', () => {
-    assertThrow(1 / 0, "unexpected type in ChronoStringDateCast for val Infinity typeof number")
+    assertThrow(
+      1 / 0,
+      'unexpected type in ChronoStringDateCast for val Infinity typeof number'
+    )
   })
 
   test('instantiate DateField', () => {
@@ -219,9 +408,9 @@ describe('Cast Function tests ->', () => {
   })
 
   test('pandas date functions', () => {
-    assertDC("Feb072009", /*--*/  new Date('2009-02-07T00:00:00.000Z')) // "MonDDYY" Month abbreviation-Day-Year with leading zeros
-    assertDC("Feb 08, 2009", /**/ new Date('2009-02-08T00:00:00.000Z')) // "Mon DD, YYYY" Month abbreviation, Day with leading zeros, Year
-    assertDC("09 Feb, 2009", new Date('2009-02-09T00:00:00.000Z')) // "DD Mon, YYYY" Day with leading zeros, Month abbreviation, Year
+    assertDC('Feb072009', /*--*/ new Date('2009-02-07T00:00:00.000Z')) // "MonDDYY" Month abbreviation-Day-Year with leading zeros
+    assertDC('Feb 08, 2009', /**/ new Date('2009-02-08T00:00:00.000Z')) // "Mon DD, YYYY" Month abbreviation, Day with leading zeros, Year
+    assertDC('09 Feb, 2009', new Date('2009-02-09T00:00:00.000Z')) // "DD Mon, YYYY" Day with leading zeros, Month abbreviation, Year
     assertDC('02/17/2009', /*--*/ new Date('2009-02-17T00:00:00.000Z')) // "MM/DD/YY" Month-Day-Year with leading zeros - Non ambiguous
     assertDC('18/02/2009', /*--*/ new Date('2009-02-18T00:00:00.000Z')) // "DD/MM/YY" Day-Month-Year with leading zeros - Non ambiguous
     assertDC('2009/02/19', /*--*/ new Date('2009-02-19T00:00:00.000Z')) // "YY/MM/DD" Year-Month-Day with leading zeros - Non ambiguous
@@ -230,36 +419,50 @@ describe('Cast Function tests ->', () => {
     assertDC('22/2/2009', /*---*/ new Date('2009-02-22T00:00:00.000Z')) // "D/M/YY"Day-Month-Year with no leading zeros - Non ambiguous
     assertDC('2009/2/23', /*---*/ new Date('2009-02-23T00:00:00.000Z')) // "YY/M/D" Year-Month-Day with no leading zeros - Non ambiguous
     assertDC(' 2/24/2009', /*--*/ new Date('2009-02-24T00:00:00.000Z')) // "bM/bD/YY" Month-Day-Year with spaces instead of leading zeros
-    assertDC('2009-02-26T00:00:00.000Z', /*--*/ new Date('2009-02-26T00:00:00.000Z')
-    )  //ISO FULL
+    assertDC(
+      '2009-02-26T00:00:00.000Z',
+      /*--*/ new Date('2009-02-26T00:00:00.000Z')
+    ) //ISO FULL
 
     assertDC('02/27/2009', new Date('2009-02-27')) //"MM/DD/YY" #Month-Day-Year with leading zeros
     assertDC(' 2/8/2009', /*--*/ new Date('2009-02-08T00:00:00.000Z')) //"bM/bD/YY" #Month-Day-Year with spaces instead of leading zeros
     assertDC(' 8/2/2009', /*--*/ new Date('2009-08-02T00:00:00.000Z')) //"bM/bD/YY" #Month-Day-Year with spaces instead of leading zeros
 
-
     assertDC('03/3/2009', /*---*/ new Date('2009-03-03T00:00:00.000Z')) //"D/M/YY"#Day-Month-Year with no leading zeros
 
-
-    assertDC('Nov 28, 2015, 7:41 AM', /*---*/ new Date('2015-11-28T07:41:00.000Z'))
-    assertDC('2015-11-26T00:00:00000Z', /*---*/ new Date('2015-11-26T00:00:00.000Z'))
-    assertDC('Fri, 27 November 2015 7:41am', /*---*/ new Date('2015-11-27T07:41:00.000Z'))
+    assertDC(
+      'Nov 28, 2015, 7:41 AM',
+      /*---*/ new Date('2015-11-28T07:41:00.000Z')
+    )
+    assertDC(
+      '2015-11-26T00:00:00000Z',
+      /*---*/ new Date('2015-11-26T00:00:00.000Z')
+    )
+    assertDC(
+      'Fri, 27 November 2015 7:41am',
+      /*---*/ new Date('2015-11-27T07:41:00.000Z')
+    )
     // this probably shouldn't pass November 27th 2015 was a Friday
-    assertDC('Sun, 27 November 2015 7:41am', /*---*/ new Date('2015-11-27T07:41:00.000Z'))
+    assertDC(
+      'Sun, 27 November 2015 7:41am',
+      /*---*/ new Date('2015-11-27T07:41:00.000Z')
+    )
   })
 
   test('date time  functions', () => {
     assertDC('02/17/2009 11:44:55', /*--*/ new Date('2009-02-17T11:44:55.000Z')) //"MM/DD/YY" #Month-Day-Year with leading zeros
   })
 
-
   test('expected parsing errors', () => {
-    assertThrow('25-Feb-19', "couldn't parse 25-Feb-19 with a certain year.  Please use an unambiguous date format")
+    assertThrow(
+      '25-Feb-19',
+      "couldn't parse 25-Feb-19 with a certain year.  Please use an unambiguous date format"
+    )
   })
   test('extraParseString', () => {
-    const df = SmartDateField({ extraParseString: "yyyyMMdd" })
-    expect(df.options.cast('20080302')).toStrictEqual(new Date('2008-03-02T00:00:00.000Z'))
+    const df = SmartDateField({ extraParseString: 'yyyyMMdd' })
+    expect(df.options.cast('20080302')).toStrictEqual(
+      new Date('2008-03-02T00:00:00.000Z')
+    )
   })
 })
-
-


### PR DESCRIPTION
Closes https://github.com/FlatFilers/platform-sdk-mono/issues/251

This fixes the issue with SmartDateField by adding a check for null, undefined, and "" in SmartDateField's `cast` function. However, based on my understanding of how it is implemented, this should not be necessary if StringChainCast is working properly (and StringChainCast is not tested). I'll continue to investigate StringChainCast, if we need a fix out in the meantime  we can merge this PR.