### PR TITLE
fix: Fix to SmartDateField DST bug

### DIFF
--- a/examples/fields/SmartDateField.ts
+++ b/examples/fields/SmartDateField.ts
@@ -94,10 +94,10 @@ const getChronoDateCast = (locale: Locales) => {
 
 export const GMTFormatDate = (val: Date, formatString: string): string => {
   const prevailingTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone
-  const d = new Date()
+  const d = new Date(val.toDateString())
   const tzHours = d.getTimezoneOffset() / 60
   const val2 = new Date(val)
-  val2.setHours(val2.getHours() + tzHours + 1)
+  val2.setHours(val2.getHours() + tzHours)
   const utcDate = utcToZonedTime(val2, prevailingTimezone)
   return format(utcDate, formatString)
 }

--- a/examples/fields/SmartDateField.ts
+++ b/examples/fields/SmartDateField.ts
@@ -97,7 +97,7 @@ export const GMTFormatDate = (val: Date, formatString: string): string => {
   const d = new Date()
   const tzHours = d.getTimezoneOffset() / 60
   const val2 = new Date(val)
-  val2.setHours(val2.getHours() + tzHours)
+  val2.setHours(val2.getHours() + tzHours + 1)
   const utcDate = utcToZonedTime(val2, prevailingTimezone)
   return format(utcDate, formatString)
 }


### PR DESCRIPTION
This PR fixes a bug with SmartDateField. When we convert the date back into a GMT-relative format for egress, we are using the **current** date to calculate the timezone offset. That only works if both the current date and the date in question are in the same state of Daylight Savings vs Standard. If one is in DST and the other is in ST, the egressed date will be off by one hour.

The fix is to get the proper timezone offset based on the passed date, instead of the current date.